### PR TITLE
fix: override serialize-javascript to patched version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3505,16 +3505,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/rc9": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/rc9/-/rc9-3.0.1.tgz",
@@ -3573,27 +3563,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/semiff": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/semiff/-/semiff-2.0.0.tgz",
@@ -3615,13 +3584,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/setimmediate": {

--- a/package.json
+++ b/package.json
@@ -59,5 +59,8 @@
         }
       }
     ]
+  },
+  "overrides": {
+    "serialize-javascript": "7.0.5"
   }
 }


### PR DESCRIPTION
## Summary
- Force `serialize-javascript` to patched `7.0.5` with npm `overrides`
- Refresh `package-lock.json` so Mocha's transitive dependency resolves to the patched version
- Removes now-unused `randombytes`/`safe-buffer` transitive lock entries from `serialize-javascript@6`

## Why
Dependabot has two open dev-scope alerts for `serialize-javascript` in `package-lock.json`:
- high severity: patched in `7.0.3`
- medium severity: patched in `7.0.5`

Mocha 11 still declares `serialize-javascript@^6.0.2` because stable Mocha still supports Node 18. This repo's current local/CI Node is compatible with `serialize-javascript@7`.

## Verification
- [x] `npm ci --no-audit`
- [x] `npm run lint:check`
- [x] `npm run build`
- [x] `npm ls serialize-javascript --all` shows `serialize-javascript@7.0.5 overridden`
- [ ] `npm test` locally: blocked because this machine has no Zotero binary (`Error: No Zotero Found.`); rely on GitHub/maintainer environment if available.
