### PR TITLE
changed manifest to allow Zotero V9

### DIFF
--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -14,7 +14,7 @@
       "id": "__addonID__",
       "update_url": "__updateURL__",
       "strict_min_version": "6.999",
-      "strict_max_version": "8.*"
+      "strict_max_version": "9.*"
     }
   }
 }


### PR DESCRIPTION
Allows compatibility with Zotero v9 #53 

Plugin needs no other changes and works as expected when bumping manifest max version to 9.